### PR TITLE
Rename positional param to `wrapped`

### DIFF
--- a/addon/components/ya-form/component.js
+++ b/addon/components/ya-form/component.js
@@ -11,5 +11,5 @@ const YaFormComponent = Component.extend({
 });
 
 export default YaFormComponent.reopenClass({
-  positionalParams: ['model']
+  positionalParams: ['wrapped']
 });

--- a/tests/unit/ya-form-test.js
+++ b/tests/unit/ya-form-test.js
@@ -2,19 +2,21 @@ import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
-const { set } = Ember;
+const { Object: EmberObject, set } = Ember;
 
 moduleForComponent('ya-form', {
   integration: true,
   beforeEach() {
-    set(this, 'user', { firstName: 'Derek', lastName: 'Zoolander' });
+    set(this, 'wrapped', EmberObject.create({
+      user: { firstName: 'Derek', lastName: 'Zoolander' }
+    }));
   }
 });
 
 test('should render the form', function(assert) {
   this.render(hbs`<div>
-                    {{#ya-form user as |form|}}
-                      <p>{{form.model.firstName}}</p>
+                    {{#ya-form wrapped as |form|}}
+                      <p>{{form.wrapped.user.firstName}}</p>
                     {{/ya-form}}
                   </div>`);
 


### PR DESCRIPTION
This commit is based on the assumption that a form component that has a
`model` and `errors` prop exists and is passed into ya-form. The use is
then:

``` hbs
{{! app/components/some-form/template }}
{{! pass `some-form` component into ya-form }}

{{#ya-form this as |form|}}
  {{#ya-input form as |yaInput|}}
    <input type={{yaInput.type}} value={{yaInput.value}}>
  {{/ya-input}}
{{/ya-form}}
```
